### PR TITLE
Removed ha labels and added endpoint default.

### DIFF
--- a/charts/aspenmesh-collector/templates/configmap.yaml
+++ b/charts/aspenmesh-collector/templates/configmap.yaml
@@ -78,13 +78,10 @@ data:
       logging:
         loglevel: info
       prometheusremotewrite:
-        endpoint: {{ .Values.promscaleEndpoint }}
-        external_labels:
-          cluster: {{ required "A cluster name is required." .Values.cluster }}
-          __replica__: {{ required "A replica name is required." .Values.replica }}
+        endpoint: {{ .Values.endpoint | default "https://metrics.cloud.aspenmesh.io/write" | quote }}
         timeout: 30s
         headers:
-          X-AM-API-KEY: {{ required "An API key is required." .Values.apiKey }}
+          X-AM-API-KEY: {{ required "An API key is required." .Values.apiKey | quote }}
         resource_to_telemetry_conversion:
           enabled: true
     service:

--- a/charts/aspenmesh-collector/values.yaml
+++ b/charts/aspenmesh-collector/values.yaml
@@ -1,7 +1,3 @@
 apiKey:
-promscaleEndpoint: https://metrics.cloud.aspenmesh.io/write
-cluster:
-replica:
 cert-manager:
   installCRDs: true
-


### PR DESCRIPTION
Remove the Prometheus HA labels from the default configuration and added a default for the metrics endpoint.