### PR TITLE
Export the app and version labels

### DIFF
--- a/charts/aspenmesh-collector/templates/configmap.yaml
+++ b/charts/aspenmesh-collector/templates/configmap.yaml
@@ -62,6 +62,22 @@ data:
                 action: keep
                 regex: istiod;http-monitoring
     processors:
+      metricstransform:
+        transforms:
+          # for all kube-state-metrics metrics, rename the label app to app.kubernetes.io/name
+          - include: ^kube_.
+            action: update
+            operations:
+              - action: update_label
+                label: app
+                new_label: app.kubernetes.io/name
+          # for all kube-state-metrics metrics, rename the label version to app.kubernetes.io/version
+          - include: ^kube_.
+            action: update
+            operations:
+              - action: update_label
+                label: version
+                new_label: app.kubernetes.io/version
       resourcedetection/eks:
         detectors: [env, eks]
         timeout: 2s
@@ -91,6 +107,7 @@ data:
             - otlp
             - prometheus
           processors:
+            - metricstransform
             - resourcedetection/eks
             - resourcedetection/aks
             - resourcedetection/gke

--- a/charts/aspenmesh-collector/templates/configmap.yaml
+++ b/charts/aspenmesh-collector/templates/configmap.yaml
@@ -69,15 +69,15 @@ data:
             action: update
             operations:
               - action: update_label
-                label: app
-                new_label: app.kubernetes.io/name
+                label: label_app
+                new_label: label_app_kubernetes_io_name
           # for all kube-state-metrics metrics, rename the label version to app.kubernetes.io/version
           - include: ^kube_.
             action: update
             operations:
               - action: update_label
-                label: version
-                new_label: app.kubernetes.io/version
+                label: label_version
+                new_label: label_app_kubernetes_io_version
       resourcedetection/eks:
         detectors: [env, eks]
         timeout: 2s

--- a/charts/aspenmesh-collector/templates/configmap.yaml
+++ b/charts/aspenmesh-collector/templates/configmap.yaml
@@ -64,17 +64,14 @@ data:
     processors:
       metricstransform:
         transforms:
-          # for all kube-state-metrics metrics, rename the label app to app.kubernetes.io/name
-          - include: ^kube_.
+          # for all kube-state-metrics metrics, rename the labels app and version to app.kubernetes.io/name and app.kubernetes.io/version
+          - include: ^kube_.*$
+            match_type: regexp
             action: update
-            operations:
+            operations:   
               - action: update_label
                 label: label_app
                 new_label: label_app_kubernetes_io_name
-          # for all kube-state-metrics metrics, rename the label version to app.kubernetes.io/version
-          - include: ^kube_.
-            action: update
-            operations:
               - action: update_label
                 label: label_version
                 new_label: label_app_kubernetes_io_version

--- a/charts/aspenmesh-collector/values.yaml
+++ b/charts/aspenmesh-collector/values.yaml
@@ -1,3 +1,6 @@
 apiKey:
 cert-manager:
   installCRDs: true
+kube-state-metrics:
+  metricLabelsAllowlist:
+    - deployments=[app.kubernetes.io/name,app.kubernetes.io/version,app,version]

--- a/charts/aspenmesh-collector/values.yaml
+++ b/charts/aspenmesh-collector/values.yaml
@@ -4,3 +4,4 @@ cert-manager:
 kube-state-metrics:
   metricLabelsAllowlist:
     - deployments=[app.kubernetes.io/name,app.kubernetes.io/version,app,version]
+    - pods=[app.kubernetes.io/name,app.kubernetes.io/version,app,version]


### PR DESCRIPTION
This ensures we are getting the app and version labels from `kube-state-metrics`. This also adds in a processor that normalizes the `app` and `version` labels.