### PR TITLE
feat: Add support for container + pod metrics.

### DIFF
--- a/charts/aspenmesh-collector/templates/clusterrole.yaml
+++ b/charts/aspenmesh-collector/templates/clusterrole.yaml
@@ -8,17 +8,46 @@ rules:
 - apiGroups:
   - ""
   resources:
-    - nodes
-    - nodes/metrics
-    - services
-    - endpoints
-    - pods
     - configmaps
+    - endpoints
     - namespaces
+    - namespaces/status
+    - nodes
+    - nodes/spec
+    - nodes/stats
+    - nodes/proxy
+    - nodes/metrics
+    - pods
+    - pods/status
+    - replicationcontrollers
+    - replicationcontrollers/status
+    - resourcequotas
+    - services
   verbs:
-      - get
-      - list
-      - watch
+    - get
+    - list
+    - watch
+- apiGroups:
+  - apps
+  resources:
+    - daemonsets
+    - deployments
+    - replicasets
+    - statefulsets
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+  - extensions
+  resources:
+    - daemonsets
+    - deployments
+    - replicasets
+  verbs:
+    - get
+    - list
+    - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/charts/aspenmesh-collector/templates/configmap.yaml
+++ b/charts/aspenmesh-collector/templates/configmap.yaml
@@ -90,6 +90,14 @@ data:
       otlp:
         protocols:
           grpc:
+    kubeletstats:
+      collection_interval: 60s
+      auth_type: "serviceAccount"
+      endpoint: "${K8S_NODE_NAME}:10250"
+      insecure_skip_verify: true
+      metric_groups:
+      - containers
+      - pod
     processors:
     exporters:
       logging:
@@ -103,6 +111,7 @@ data:
         traces:
           receivers:
             - otlp
+            - kubeletstats
           processors: []
           exporters:
             - logging

--- a/charts/aspenmesh-collector/templates/daemonset.yaml
+++ b/charts/aspenmesh-collector/templates/daemonset.yaml
@@ -22,6 +22,11 @@ spec:
           image: "ghcr.io/aspenmesh/aspenmesh-collector:0.1.1"
           args:
             - "--config=/conf/agent.yaml"
+          env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           volumeMounts:
             - name: agent-config
               mountPath: /conf


### PR DESCRIPTION
feat: Add support for container + pod metrics.

Added support for collecting `container` and `pod` metrics via the `otel-agent` using the `kubeletstatsreceiver`. 
