### PR TITLE
bug: fixed kubeletstats in wrong pipeline

### DIFF
--- a/charts/aspenmesh-collector/Chart.yaml
+++ b/charts/aspenmesh-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspenmesh-collector
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.1.0
 description: Aspen Mesh Collector
 icon: https://aspenmesh.github.io/aspenmesh-charts/docs/images/aspenmesh.png

--- a/charts/aspenmesh-collector/templates/configmap.yaml
+++ b/charts/aspenmesh-collector/templates/configmap.yaml
@@ -109,17 +109,10 @@ data:
     service:
       pipelines:
         traces:
-          receivers:
-            - otlp
-            - kubeletstats
+          receivers: [otlp]
           processors: []
-          exporters:
-            - logging
-            - otlp
+          exporters: [logging, otlp]
         metrics:
-          receivers:
-            - otlp
+          receivers: [otlp, kubeletstats]
           processors: []
-          exporters:
-            - logging
-            - otlp
+          exporters: 


### PR DESCRIPTION
Fixed the` kubeletstats` receiver declaration defined in the wrong pipeline.