### PR TITLE
bug: metric group has invalid key

### DIFF
--- a/charts/aspenmesh-collector/Chart.yaml
+++ b/charts/aspenmesh-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspenmesh-collector
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: 0.1.0
 description: Aspen Mesh Collector
 icon: https://aspenmesh.github.io/aspenmesh-charts/docs/images/aspenmesh.png

--- a/charts/aspenmesh-collector/templates/configmap.yaml
+++ b/charts/aspenmesh-collector/templates/configmap.yaml
@@ -90,14 +90,14 @@ data:
       otlp:
         protocols:
           grpc:
-    kubeletstats:
-      collection_interval: 60s
-      auth_type: "serviceAccount"
-      endpoint: "${K8S_NODE_NAME}:10250"
-      insecure_skip_verify: true
-      metric_groups:
-      - containers
-      - pod
+      kubeletstats:
+        collection_interval: 60s
+        auth_type: "serviceAccount"
+        endpoint: "${K8S_NODE_NAME}:10250"
+        insecure_skip_verify: true
+        metric_groups:
+        - container
+        - pod
     processors:
     exporters:
       logging:
@@ -115,4 +115,4 @@ data:
         metrics:
           receivers: [otlp, kubeletstats]
           processors: []
-          exporters: 
+          exporters: [logging, otlp]


### PR DESCRIPTION
The `metric_groups` declaration contained an invalid key for collecting container metrics.  