### PR TITLE
Collect replicaset info

### DIFF
--- a/charts/aspenmesh-collector/Chart.yaml
+++ b/charts/aspenmesh-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspenmesh-collector
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: 0.1.0
 description: Aspen OpenTelemetry Collector
 icon: https://aspenmesh.github.io/aspenmesh-charts/docs/images/aspenmesh.png

--- a/charts/aspenmesh-collector/values.yaml
+++ b/charts/aspenmesh-collector/values.yaml
@@ -4,10 +4,12 @@ cert-manager:
   installCRDs: true
 kube-state-metrics:
   collectors:
+    - replicasets
     - deployments
     - pods
     - services
   metricLabelsAllowlist:
+    - replicasets=[app.kubernetes.io/name,app.kubernetes.io/version,app,version]
     - deployments=[app.kubernetes.io/name,app.kubernetes.io/version,app,version]
     - pods=[app.kubernetes.io/name,app.kubernetes.io/version,app,version]
     - services=[app.kubernetes.io/name,app.kubernetes.io/version,app,version]


### PR DESCRIPTION
This will send us replicaset information that we will need in order to connect Deployments to Pods. Without this there is no great way to match deployments to pods since there is no deployment label on pod metrics.