### PR TITLE
Add app/version labels to metrics processed through k8sattributes

### DIFF
--- a/charts/aspenmesh-collector/Chart.yaml
+++ b/charts/aspenmesh-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspenmesh-collector
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: 0.1.0
 description: Aspen OpenTelemetry Collector
 icon: https://aspenmesh.github.io/aspenmesh-charts/docs/images/aspenmesh.png

--- a/charts/aspenmesh-collector/templates/configmap.yaml
+++ b/charts/aspenmesh-collector/templates/configmap.yaml
@@ -36,6 +36,9 @@ data:
             - k8s.namespace.name
             - k8s.node.name
             - k8s.pod.start_time
+          labels:
+            - tag_name: label_$$1
+              key_regex: (app.kubernetes.io/.*)
         pod_association:
         - sources:
           - from: resource_attribute


### PR DESCRIPTION
This will add app/version labels to data collected by the kubelet stats receiver and enable us to filter the metrics by application version when rolling up the metrics.

### Before
```json
      {
        "metric": {
          "__name__": "container_cpu_utilization",
          "__tenant__": "f904fd83-324d-456e-a855-1d048156ca5e",
          "cloud_platform": "aws_eks",
          "cloud_provider": "aws",
          "k8s_container_name": "promscale",
          "k8s_deployment_name": "promscale",
          "k8s_namespace_name": "istio-system",
          "k8s_node_name": "ip-192-168-17-151.us-west-2.compute.internal",
          "k8s_pod_name": "promscale-6585bc8fb6-dzzs6",
          "k8s_pod_start_time": "2022-11-29 16:00:38 +0000 UTC",
          "k8s_pod_uid": "74f47e35-7115-4cda-bd35-230a6351d386"
        },
        "value": [
          1672158552.238,
          "0.008010986"
        ]
      }
```

### After
```json
      {
        "metric": {
          "__name__": "container_cpu_utilization",
          "__tenant__": "f904fd83-324d-456e-a855-1d048156ca5e",
          "cloud_platform": "aws_eks",
          "cloud_provider": "aws",
          "k8s_container_name": "promscale",
          "k8s_deployment_name": "promscale",
          "k8s_namespace_name": "istio-system",
          "k8s_node_name": "ip-192-168-17-151.us-west-2.compute.internal",
          "k8s_pod_name": "promscale-6585bc8fb6-dzzs6",
          "k8s_pod_start_time": "2022-11-29 16:00:38 +0000 UTC",
          "k8s_pod_uid": "74f47e35-7115-4cda-bd35-230a6351d386",
          "label_app_kubernetes_io_component": "connector",
          "label_app_kubernetes_io_name": "promscale",
          "label_app_kubernetes_io_version": "0.13.0"
        },
        "value": [
          1672158552.238,
          "0.008010986"
        ]
      }
```